### PR TITLE
Use openssl 1.0.2h

### DIFF
--- a/nginx-pagespeed/Dockerfile
+++ b/nginx-pagespeed/Dockerfile
@@ -13,7 +13,7 @@ ENV PAGESPEED_VERSION 1.10.33.6
 ENV HEADERS_MORE_VERSION 0.29
 
 # https://www.openssl.org/source
-ENV OPENSSL_VERSION 1.0.1s
+ENV OPENSSL_VERSION 1.0.2h
 
 RUN useradd -r -s /usr/sbin/nologin nginx && mkdir -p /var/log/nginx /var/cache/nginx && \
 	apt-get update && \
@@ -95,4 +95,3 @@ RUN chmod 750 /app/bin/*.sh
 RUN /app/bin/init_nginx.sh
 
 CMD ["/sbin/my_init"]
-

--- a/nginx-pagespeed/README.md
+++ b/nginx-pagespeed/README.md
@@ -49,7 +49,7 @@ docker run -e "UPLOAD_MAX_SIZE=10M" funkygibbon/nginx-pagespeed
 ### Security
 
 Nginx is compiled from mainline source according to Ubuntu compile flags, with the following modifcations:
-- includes latest OpenSSL 1.0.1 sources - https://www.openssl.org/source/
+- includes latest OpenSSL 1.0.2h sources - https://www.openssl.org/source/
 - includes latest Google Pagespeed - https://github.com/pagespeed/ngx_pagespeed/releases
 - includes headers-more module to enable removal of sensitive headers such as X-Powered-By
 - `http_ssi_module` and `http_autoindex_module` disabled

--- a/nginx-pagespeed/README.md
+++ b/nginx-pagespeed/README.md
@@ -1,6 +1,6 @@
 # Nginx + Pagespeed + OpenSSL
 
-![Nginx 1.9.10](https://img.shields.io/badge/nginx-1.9.10-brightgreen.svg) ![ngx_pagespeed 1.9.33.6](https://img.shields.io/badge/pagespeed-1.9.33.6-brightgreen.svg) ![OpenSSL 1.0.1s](https://img.shields.io/badge/OpenSSL-1.0.1s-brightgreen.svg)
+![Nginx 1.9.10](https://img.shields.io/badge/nginx-1.9.10-brightgreen.svg) ![ngx_pagespeed 1.9.33.6](https://img.shields.io/badge/pagespeed-1.9.33.6-brightgreen.svg) ![OpenSSL 1.0.2h](https://img.shields.io/badge/OpenSSL-1.0.2h-brightgreen.svg)
 
 Built on [funkygibbon/ubuntu](https://registry.hub.docker.com/u/funkygibbon/ubuntu/), a lightly modified [Phusion Base Image](https://phusion.github.io/baseimage-docker/)
 
@@ -18,7 +18,7 @@ SSL configuration is stored in `/etc/nginx/ssl`
 
 Nginx reads `/etc/nginx/sites-enabled` for its virtual hosts, and comes with some sane defaults for out-of-the-box webserving.
 
-### Environment 
+### Environment
 
 Nginx is configurable via environment variables, which are applied to the configuration on each service start, so you can adjust server parameters on the fly with, for example:
 


### PR DESCRIPTION
This should allow HTTP2 to work with Chrome and any other browsers that need ALPN. Currently HTTP2 will work with Firefox since it uses NPN. See this awesome explanation for why a newer version of openssl is needed to get HTTP2 working with Chrome http://serverfault.com/a/733556/71373

Also, another good reason is that support for 1.0.1 will be discontinued by the end of this year according to https://www.openssl.org/source/
