### PR TITLE
Update OpenSSL to 1.1.0g from 1.1.0f

### DIFF
--- a/nginx-pagespeed/Dockerfile
+++ b/nginx-pagespeed/Dockerfile
@@ -17,7 +17,7 @@ ENV NGINX_PAGESPEED_RELEASE_STATUS stable
 ENV HEADERS_MORE_VERSION 0.32
 
 # https://www.openssl.org/source
-ENV OPENSSL_VERSION 1.1.0f
+ENV OPENSSL_VERSION 1.1.0g
 
 COPY ./bin/download_pagespeed.sh /app/bin/download_pagespeed.sh
 


### PR DESCRIPTION
This release was made available on 02 November 2017 and includes security fixes

As we know with all things SSL if you are not up to date you are gonna be the next victim of the Heartbleed, POODLE, FREAK, DROWN security hole (seriously who comes up with these names)

https://www.openssl.org/