### PR TITLE
 Nginx to 1.13.7 - Segmentation faults 

### DIFF
--- a/nginx-pagespeed/Dockerfile
+++ b/nginx-pagespeed/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 80
 EXPOSE 443
 
 # http://nginx.org/en/download.html
-ENV NGINX_VERSION 1.13.6
+ENV NGINX_VERSION 1.13.7
 
 # https://github.com/pagespeed/ngx_pagespeed/releases
 ENV NGINX_PAGESPEED_VERSION latest


### PR DESCRIPTION
Changes with nginx 1.13.7                                        21 Nov 2017

    *) Bugfix: in the $upstream_status variable.

    *) Bugfix: a segmentation fault might occur in a worker process if a
       backend returned a "101 Switching Protocols" response to a
       subrequest.

    *) Bugfix: a segmentation fault occurred in a master process if a shared
       memory zone size was changed during a reconfiguration and the
       reconfiguration failed.

    *) Bugfix: in the ngx_http_fastcgi_module.

    *) Bugfix: nginx returned the 500 error if parameters without variables
       were specified in the "xslt_stylesheet" directive.

    *) Workaround: "gzip filter failed to use preallocated memory" alerts
       appeared in logs when using a zlib library variant from Intel.

    *) Bugfix: the "worker_shutdown_timeout" directive did not work when
       using mail proxy and when proxying WebSocket connections.