### PR TITLE
Update Nginx to 1.13.12

### DIFF
--- a/nginx-pagespeed/Dockerfile
+++ b/nginx-pagespeed/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 80
 EXPOSE 443
 
 # http://nginx.org/en/download.html
-ENV NGINX_VERSION 1.13.7
+ENV NGINX_VERSION 1.13.12
 
 # https://github.com/pagespeed/ngx_pagespeed/releases
 ENV NGINX_PAGESPEED_VERSION latest


### PR DESCRIPTION
Changes with nginx 1.13.12                                       10 Apr 2018

    *) Bugfix: connections with gRPC backends might be closed unexpectedly
       when returning a large response.


Changes with nginx 1.13.11                                       03 Apr 2018

    *) Feature: the "proxy_protocol" parameter of the "listen" directive now
       supports the PROXY protocol version 2.

    *) Bugfix: nginx could not be built with OpenSSL 1.1.1 statically on
       Linux.

    *) Bugfix: in the "http_404", "http_500", etc. parameters of the
       "proxy_next_upstream" directive.


Changes with nginx 1.13.10                                       20 Mar 2018

    *) Feature: the "set" parameter of the "include" SSI directive now
       allows writing arbitrary responses to a variable; the
       "subrequest_output_buffer_size" directive defines maximum response
       size.

    *) Feature: now nginx uses clock_gettime(CLOCK_MONOTONIC) if available,
       to avoid timeouts being incorrectly triggered on system time changes.

    *) Feature: the "escape=none" parameter of the "log_format" directive.
       Thanks to Johannes Baiter and Calin Don.

    *) Feature: the $ssl_preread_alpn_protocols variable in the
       ngx_stream_ssl_preread_module.

    *) Feature: the ngx_http_grpc_module.

    *) Bugfix: in memory allocation error handling in the "geo" directive.

    *) Bugfix: when using variables in the "auth_basic_user_file" directive
       a null character might appear in logs.
       Thanks to Vadim Filimonov.


Changes with nginx 1.13.9                                        20 Feb 2018

    *) Feature: HTTP/2 server push support; the "http2_push" and
       "http2_push_preload" directives.

    *) Bugfix: "header already sent" alerts might appear in logs when using
       cache; the bug had appeared in 1.9.13.

    *) Bugfix: a segmentation fault might occur in a worker process if the
       "ssl_verify_client" directive was used and no SSL certificate was
       specified in a virtual server.

    *) Bugfix: in the ngx_http_v2_module.

    *) Bugfix: in the ngx_http_dav_module.


Changes with nginx 1.13.8                                        26 Dec 2017

    *) Feature: now nginx automatically preserves the CAP_NET_RAW capability
       in worker processes when using the "transparent" parameter of the
       "proxy_bind", "fastcgi_bind", "memcached_bind", "scgi_bind", and
       "uwsgi_bind" directives.

    *) Feature: improved CPU cache line size detection.
       Thanks to Debayan Ghosh.

    *) Feature: new directives in vim syntax highlighting scripts.
       Thanks to Gena Makhomed.

    *) Bugfix: binary upgrade refused to work if nginx was re-parented to a
       process with PID different from 1 after its parent process has
       finished.

    *) Bugfix: the ngx_http_autoindex_module incorrectly handled requests
       with bodies.

    *) Bugfix: in the "proxy_limit_rate" directive when used with the
       "keepalive" directive.

    *) Bugfix: some parts of a response might be buffered when using
       "proxy_buffering off" if the client connection used SSL.
       Thanks to Patryk Lesiewicz.

    *) Bugfix: in the "proxy_cache_background_update" directive.

    *) Bugfix: it was not possible to start a parameter with a variable in
       the "${name}" form with the name in curly brackets without enclosing
       the parameter into single or double quotes.